### PR TITLE
Skip processing table if zero rows found

### DIFF
--- a/cmd/check_mysql2sqlite/main.go
+++ b/cmd/check_mysql2sqlite/main.go
@@ -326,6 +326,14 @@ func main() {
 			return
 		}
 
+		if mysqlRowsCount == 0 && sqliteRowsCount == 0 {
+			log.Infof(
+				"Zero rows for table %s in both databases; skipping further validation for this table",
+				table,
+			)
+			continue
+		}
+
 		mysqlRows, readQueryErr := mysqlDB.Query(querySet[config.SQLQueriesRead])
 		if readQueryErr != nil {
 			nagiosExitState.LastError = readQueryErr


### PR DESCRIPTION
For both binaries, check source database rows count early and skip further processing of that table. This helps prevent unnecessary connections from accumulating in the pool and prevents wasted effort.

For the Nagios plugin, the table is only skipped if *both* databases have empty tables, otherwise it continues to apply validation checks and will fail early as before.

fixes GH-20