### PR TITLE
Refactor SQLite database generation

### DIFF
--- a/cmd/check_mysql2sqlite/main.go
+++ b/cmd/check_mysql2sqlite/main.go
@@ -344,7 +344,7 @@ func main() {
 			continue
 		}
 
-		mysqlRows, readQueryErr := mysqlDB.Query(querySet[config.SQLQueriesRead])
+		mysqlRows, readQueryErr := mysqlDB.Query(querySet[dbqs.SQLQueriesRead])
 		if readQueryErr != nil {
 			nagiosExitState.LastError = readQueryErr
 			nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
@@ -353,7 +353,7 @@ func main() {
 			nagiosExitState.ServiceOutput = fmt.Sprintf(
 				"%s: %s query for table %s in MySQL database failed: %v",
 				nagios.StateCRITICALLabel,
-				config.SQLQueriesRead,
+				dbqs.SQLQueriesRead,
 				table,
 				readQueryErr,
 			)
@@ -373,7 +373,7 @@ func main() {
 		)
 		logConnStats()
 
-		sqliteRows, readQueryErr := sqliteDB.Query(querySet[config.SQLQueriesRead])
+		sqliteRows, readQueryErr := sqliteDB.Query(querySet[dbqs.SQLQueriesRead])
 		if readQueryErr != nil {
 			nagiosExitState.LastError = readQueryErr
 			nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
@@ -382,7 +382,7 @@ func main() {
 			nagiosExitState.ServiceOutput = fmt.Sprintf(
 				"%s: %s query for table %s in SQLite database failed: %v",
 				nagios.StateCRITICALLabel,
-				config.SQLQueriesRead,
+				dbqs.SQLQueriesRead,
 				table,
 				readQueryErr,
 			)

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -34,15 +34,6 @@ const (
 	MySQLEncryptionDisabled   string = "false"
 )
 
-// Queries used to retrieve data from MySQL database and manage local SQLite
-// database
-const (
-	SQLQueriesRead  string = "read"
-	SQLQueriesNew   string = "new"
-	SQLQueriesWrite string = "write"
-	SQLQueriesIndex string = "index"
-)
-
 // Default flag settings if not overridden by user input.
 const (
 	// defaultTrimWhitespace controls whether leading and trailing whitespace

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -9,6 +9,8 @@ package config
 
 import (
 	"time"
+
+	"github.com/atc0005/mysql2sqlite/internal/dbqs"
 )
 
 // ConfigFile returns the user-provided path to the config file for this
@@ -297,7 +299,7 @@ func (c Config) ConnectionTimeout() time.Duration {
 // DBQueries returns the user-provided collection of tables and the queries
 // used to read from a source database and write to a SQLite database. If not
 // provided, nil is returned in order to force validation to fail.
-func (c Config) DBQueries() SQLQueries {
+func (c Config) DBQueries() dbqs.SQLQueries {
 	switch {
 	case c.configFileSettings.Queries != nil:
 		return c.configFileSettings.Queries

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -7,12 +7,10 @@
 
 package config
 
-import "github.com/alexflint/go-arg"
-
-// SQLQueries is a map of maps representing a collection of tables and the
-// queries used to read from a source database and write to a SQLite database.
-// Example: queries["virtual_domains"]["read"] = "SELECT * FROM virtual_domains"
-type SQLQueries map[string]map[string]string
+import (
+	"github.com/alexflint/go-arg"
+	"github.com/atc0005/mysql2sqlite/internal/dbqs"
+)
 
 type generalSettings struct {
 	TrimWhitespace       *bool `yaml:"trim_leading_trailing_whitespace"`
@@ -52,7 +50,7 @@ type configFileSettings struct {
 	MySQLConfig  mysqlConfig     `yaml:"mysql_config"`
 	SQLiteConfig sqliteConfig    `yaml:"sqlite_config"`
 	Logging      loggingConfig   `yaml:"logging"`
-	Queries      SQLQueries      `yaml:"queries"`
+	Queries      dbqs.SQLQueries `yaml:"queries"`
 }
 
 type flagSettings struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/atc0005/mysql2sqlite/internal/caller"
+	"github.com/atc0005/mysql2sqlite/internal/dbqs"
 )
 
 // TCP port ranges
@@ -227,13 +228,13 @@ func (c Config) Validate() error {
 			// each of these query types should be defined within the
 			// configuration file with `index` being optional
 			expectedQuerySet := []string{
-				SQLQueriesRead,
-				SQLQueriesNew,
-				SQLQueriesWrite,
+				dbqs.SQLQueriesRead,
+				dbqs.SQLQueriesNew,
+				dbqs.SQLQueriesWrite,
 			}
 
 			if c.SQLiteCreateIndexes() {
-				expectedQuerySet = append(expectedQuerySet, SQLQueriesIndex)
+				expectedQuerySet = append(expectedQuerySet, dbqs.SQLQueriesIndex)
 			}
 
 			for _, expectedQuery := range expectedQuerySet {

--- a/internal/dbqs/dbqs.go
+++ b/internal/dbqs/dbqs.go
@@ -17,6 +17,25 @@ import (
 	"github.com/atc0005/mysql2sqlite/internal/caller"
 )
 
+// SQLQueries is a map of maps representing a collection of tables and the
+// queries used to read from a source database and write to a SQLite database.
+// Example: queries["virtual_domains"]["read"] = "SELECT * FROM virtual_domains"
+type SQLQueries map[string]map[string]string
+
+// SQLQuerySet is a map of query type to query. Each entry is used to read
+// from a source database table, create, write to or update indexes for a new
+// database table in the generated SQLite database.
+type SQLQuerySet map[string]string
+
+// Queries used to retrieve data from MySQL database and manage local SQLite
+// database
+const (
+	SQLQueriesRead  string = "read"
+	SQLQueriesNew   string = "new"
+	SQLQueriesWrite string = "write"
+	SQLQueriesIndex string = "index"
+)
+
 // var ErrStmtClose error = errors.New("failed to close statement")
 // var ErrTableCount error = errors.New("failed to retrieve row count for table")
 
@@ -92,8 +111,7 @@ func VerifyDBConn(ctx context.Context, db *sql.DB, retries int, retryDelay time.
 
 }
 
-// RowsCount is a helper function that is used to return the number of rows
-// for a specified table.
+// RowsCount returns the number of rows for a specified table.
 func RowsCount(db *sql.DB, table string) (int, error) {
 	var rowsCount int
 	rcQuery := fmt.Sprintf("SELECT COUNT(*) as count FROM %s", table)
@@ -107,4 +125,77 @@ func RowsCount(db *sql.DB, table string) (int, error) {
 	}
 
 	return rowsCount, nil
+}
+
+// PrepareSQLiteDB prepares a SQLite database for incoming data from the
+// source database. As of the current version, this includes dropping tables
+// and recreating them along with optional indexes, if enabled.
+func PrepareSQLiteDB(tx *sql.Tx, querySet SQLQuerySet, table string, createIndexes bool) error {
+	// Recreate SQLite database tables.
+	//
+	// TODO: Research syncing tables instead of recreating each time
+
+	// FIXME: What is a better way to drop the table programatically?
+	dropTableStmt := fmt.Sprintf("DROP TABLE IF EXISTS %s", table)
+	if _, err := tx.Exec(dropTableStmt); err != nil {
+		log.Errorf(
+			"failed to run query to drop (potentially) preexisting table %s: %v",
+			table,
+			err,
+		)
+		return err
+	}
+	log.Debugf("Successfully ran DROP TABLE query for table %s", table)
+
+	dropIndexStmt := fmt.Sprintf("DROP INDEX IF EXISTS %s", table)
+	if _, err := tx.Exec(dropIndexStmt); err != nil {
+		log.Errorf(
+			"failed to run query to drop (potentially) preexisting index for table %s: %v",
+			table,
+			err,
+		)
+		return err
+	}
+	log.Debugf("Successfully ran DROP INDEX query for table %s", table)
+
+	if _, err := tx.Exec(querySet[SQLQueriesNew]); err != nil {
+		log.Errorf(
+			"failed to run query to create table %s: %v",
+			table,
+			err,
+		)
+		return err
+	}
+	log.Debugf("Created table %s in SQLite database", table)
+
+	// Q: does this cause an error?
+	// A: no, attempting to retrieve a key *not* in a map returns a zero
+	// value, in this case an empty string value. Executing an empty
+	// string/query appears to be "valid", which gives unexpected results.
+	// Our validation method will have to catch problems like this one.
+	//
+	// if _, err := sqliteDB.Exec(""); err != nil {
+	// 	log.Errorf(
+	// 		"failed to run empty exec query for table %s",
+	// 		table,
+	// 		err,
+	// 	)
+	//	return
+	// }
+
+	if createIndexes {
+		if _, err := tx.Exec(querySet[SQLQueriesIndex]); err != nil {
+
+			log.Errorf(
+				"failed to run query to create index for table %s: %v",
+				table,
+				err,
+			)
+			return err
+		}
+		log.Debugf("Created index for table %s in SQLite database", table)
+	}
+
+	log.Debug("SQLite database is ready")
+	return nil
 }


### PR DESCRIPTION
- Move SQL query constants, map of queries and map of table
  to map of query set  from `config` package to `dbqs` package

- Move SQLite preparation code out of main to `dbqs` package as
  new `PrepareSQLiteDB` func

- Update misc doc comments

I'm not entirely happy with the results, but it seems a bit
better than before. Once I refactor more of the codebase I will
likely return to this code and refine further.

In particular, the `config` package now depends directly on the
`dbqs` package for constants and types. This was done so that
the `dbqs` package would be aware of those now relocated types
and constants, but this dependency is questionable.