### PR TITLE
Emit successful config load msg at startup

### DIFF
--- a/cmd/check_mysql2sqlite/main.go
+++ b/cmd/check_mysql2sqlite/main.go
@@ -77,6 +77,8 @@ func main() {
 
 	log.Info(config.Branding())
 
+	log.Infof("Successfully loaded configuration file %s", cfg.ConfigFileUsed())
+
 	// Only issue warning if stderr was not chosen as output target
 	if cfg.LogOutput() != config.LogOutputStderr {
 		log.Warn("Reminder: Use `--log-output stderr` flag to prevent interleaving log output with Nagios status information")

--- a/cmd/mysql2sqlite/main.go
+++ b/cmd/mysql2sqlite/main.go
@@ -33,6 +33,8 @@ func main() {
 
 	log.Info(config.Branding())
 
+	log.Infof("Successfully loaded configuration file %s", cfg.ConfigFileUsed())
+
 	// Create context that can be used to cancel background jobs.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -75,6 +75,21 @@ func (c Config) LogDBStats() bool {
 	}
 }
 
+// ConfigFileUsed returns the configuration file that was located and loaded
+// for application use. This may match the user-specified file or it may
+// instead be an alternate file automatically located if the user-specified
+// file could not be located. This method relies upon the configuration
+// validation checks applied at startup to ensure that a valid configuration
+// file is returned.
+func (c Config) ConfigFileUsed() string {
+	switch {
+	case c.configFileUsed != "":
+		return c.configFileUsed
+	default:
+		return ""
+	}
+}
+
 // DBServerReadTimeout returns the user-provided choice of what timeout value to use for
 // attempts to query the remote database server. If not set, returns the
 // default value for our application.


### PR DESCRIPTION
This can be useful for telling at a glance which configuration
file was detected and used. Because this behavior is automatic
and uses a hierarchy, a configuration file can be used that
the user might not expect.

This behavior is subject to change in the future. Emitting the
config file used is a useful workaround for now.