### PR TITLE
Clarify plans re max idle connection time support

### DIFF
--- a/cmd/check_mysql2sqlite/main.go
+++ b/cmd/check_mysql2sqlite/main.go
@@ -138,7 +138,10 @@ func main() {
 	mysqlDB.SetMaxOpenConns(cfg.MySQLMaxOpenConns())
 	mysqlDB.SetMaxIdleConns(cfg.MySQLMaxIdleConns())
 
-	// Disabled for now in order to support Go 1.14. See GH-28 for details.
+	// Disabled for now in order to support Go 1.14. Re-enable when Go 1.16 is
+	// released (at which point Go 1.15 becomes the oldest Go version still
+	// supported) or we opt to drop Go 1.14 support. See GH-28 and GH-37 for
+	// details.
 	// mysqlDB.SetConnMaxIdleTime(cfg.MySQLConnMaxIdleTime()) // Go 1.15+
 
 	// Test MySQL database connection before proceeding further

--- a/cmd/mysql2sqlite/main.go
+++ b/cmd/mysql2sqlite/main.go
@@ -77,7 +77,10 @@ func main() {
 	mysqlDB.SetMaxOpenConns(cfg.MySQLMaxOpenConns())
 	mysqlDB.SetMaxIdleConns(cfg.MySQLMaxIdleConns())
 
-	// Disabled for now in order to support Go 1.14. See GH-28 for details.
+	// Disabled for now in order to support Go 1.14. Re-enable when Go 1.16 is
+	// released (at which point Go 1.15 becomes the oldest Go version still
+	// supported) or we opt to drop Go 1.14 support. See GH-28 and GH-37 for
+	// details.
 	// mysqlDB.SetConnMaxIdleTime(cfg.MySQLConnMaxIdleTime()) // Go 1.15+
 
 	// test MySQL database connection before proceeding further

--- a/contrib/mysql2sqlite/config.example.yaml
+++ b/contrib/mysql2sqlite/config.example.yaml
@@ -79,7 +79,13 @@ mysql_config:
   # connections may be closed lazily before reuse.
   #
   # Specified in seconds.
-  max_idle_connection_time: 10
+  #
+  # Disabled for now in order to support Go 1.14. Re-enable when Go 1.16 is
+  # released (at which point Go 1.15 becomes the oldest Go version still
+  # supported) or we opt to drop Go 1.14 support. See GH-28 and GH-37 for
+  # details.
+  #
+  # max_idle_connection_time: 10
 
 sqlite_config:
   # The "short" name of the SQLite database file. Do not specify the directory


### PR DESCRIPTION
Explicitly note that we're disabling the support until Go 1.16 is released or we opt to drop Go 1.14 as a build target.

refs GH-37
refs GH-28