### PR TITLE
Update docs to cover contrib content, apps "story"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,181 @@
+
+<!-- omit in toc -->
 # mysql2sqlite
 
-Mirror MySQL database tables to SQLite
+Mirror MySQL database tables to local SQLite database.
+
+[![Latest Release](https://img.shields.io/github/release/atc0005/mysql2sqlite.svg?style=flat-square)](https://github.com/atc0005/mysql2sqlite/releases/latest)
+[![GoDoc](https://godoc.org/github.com/atc0005/mysql2sqlite?status.svg)](https://godoc.org/github.com/atc0005/mysql2sqlite)
+[![Validate Codebase](https://github.com/atc0005/mysql2sqlite/workflows/Validate%20Codebase/badge.svg)](https://github.com/atc0005/mysql2sqlite/actions?query=workflow%3A%22Validate+Codebase%22)
+[![Validate Docs](https://github.com/atc0005/mysql2sqlite/workflows/Validate%20Docs/badge.svg)](https://github.com/atc0005/mysql2sqlite/actions?query=workflow%3A%22Validate+Docs%22)
+[![Lint and Build using Makefile](https://github.com/atc0005/mysql2sqlite/workflows/Lint%20and%20Build%20using%20Makefile/badge.svg)](https://github.com/atc0005/mysql2sqlite/actions?query=workflow%3A%22Lint+and+Build+using+Makefile%22)
+[![Quick Validation](https://github.com/atc0005/mysql2sqlite/workflows/Quick%20Validation/badge.svg)](https://github.com/atc0005/mysql2sqlite/actions?query=workflow%3A%22Quick+Validation%22)
+
+<!-- omit in toc -->
+## Table of Contents
+
+- [Project home](#project-home)
+- [Overview](#overview)
+  - [`mysql2sqlite`](#mysql2sqlite)
+  - [`check_mysql2sqlite`](#check_mysql2sqlite)
+- [Features](#features)
+- [Changelog](#changelog)
+- [Requirements](#requirements)
+  - [Building source code](#building-source-code)
+  - [Running](#running)
+- [Documentation](#documentation)
+  - [Assumptions](#assumptions)
+  - [Build applications](#build-applications)
+  - [Deploy applications](#deploy-applications)
+  - [Configure applications](#configure-applications)
+- [License](#license)
+- [References](#references)
+
+## Project home
+
+See [our GitHub repo](https://github.com/atc0005/mysql2sqlite) for the latest
+code, to file an issue or submit improvements for review and potential
+inclusion into the project.
 
 ## Overview
 
-## Instructions
+This repo contains tools used to mirror a remote MySQL database to a local
+SQLite database. Nearly all options are controlled via a YAML-formatted
+configuration file.
 
-### Setup development environment
+| Tool Name            | Description                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------- |
+| `mysql2sqlite`       | CLI app used to mirror a remote MySQL database to a local SQLite database.                            |
+| `check_mysql2sqlite` | Nagios plugin used to validate synchronization status between remote MySQL and local SQLite database. |
 
-1. Create a new LXD container or VM
-   - as of this writing Ubuntu 16.04 LTS is the quickest setup path due to the
-     assumptions made by the `mysql2sqlite-dev` project
-1. Clone the `mysql2sqlite-dev` project within this new environment
-1. Run bash scripts
-   1. `bash bin/setup_dev_environment.sh`
-   1. `bash bin/create_db.sh`
-   1. `python3 /tmp/mysql2sqlite-dev/bin/validate_dbs.py`
-1. Setup Go development environment
-   1. [Download](https://golang.org/dl/) Go
-   1. [Install](https://golang.org/doc/install) Go
-      - NOTE: Pay special attention to the remarks about `$HOME/.profile`
-1. Clone *this* repo
+### `mysql2sqlite`
 
-### Build
+CLI app used to mirror a remote MySQL database to a local SQLite database.
+This application can be run as a one-off task or via a cron job or other
+automated means.
 
-TODO: Flesh this out with Makefile example, etc.
+### `check_mysql2sqlite`
+
+Nagios plugin used to validate synchronization status between a remote MySQL
+database and a local target SQLite database.
+
+The output for this application is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for use in email and Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+## Features
+
+- CLI tool for mirroring MySQL database tables to SQLite database
+- Nagios plugin for validating mirrored SQLite database against the original
+  source
+- Configurable source database, destination database settings
+- Configurable connection retry, retry delay behavior
+- Configurable logging settings
+  - level
+  - output "target" (`stdout`, `stderr`)
+  - format
+
+See the ([configuration](docs/configure.md)) documentation for all supported
+settings.
+
+## Changelog
+
+See the [`CHANGELOG.md`](CHANGELOG.md) file for the changes associated with
+each release of this application. Changes that have been merged to `master`,
+but not yet an official release may also be noted in the file under the
+`Unreleased` section. A helpful link to the Git commit history since the last
+official release is also provided for further review.
+
+## Requirements
+
+The following is a loose guideline. Other combinations of Go and operating
+systems for building and running tools from this repo may work, but have not
+been tested.
+
+### Building source code
+
+- Go 1.14+
+- `CGO_ENABLED=1` environment variable (if not set by default)
+  - requirement of SQLite database driver used
+- `GCC`
+- `make`
+  - if using the provided `Makefile`
+
+### Running
+
+- Windows 7, Server 2008R2 or later
+- Windows 10
+- Ubuntu Linux 16.04+
+
+See official [Go install notes][go-docs-install] for specific operating
+systems supported.
+
+## Documentation
+
+### Assumptions
+
+Various assumptions are made in this documentation. These assumptions are made
+in order to provide a more complete example that illustrates how binaries
+provided by this project may be used. Modify as you feel appropriate.
+
+### Build applications
+
+See the [build](docs/build.md) instructions for more information.
+
+As an alternative to building the binaries yourself, this project also
+periodically provides binaries via new releases. If binaries for your platform
+are not provided, please [file an
+issue](https://github.com/atc0005/mysql2sqlite/issues/new) so that we may
+evaluate the requirements for providing those binaries with future releases.
+
+### Deploy applications
+
+See the [deployment](docs/deploy.md) documentation for details.
+
+### Configure applications
+
+See the [configure](docs/configure.md) doc for details.
+
+## License
+
+From the [LICENSE](LICENSE) file:
+
+```license
+MIT License
+
+Copyright (c) 2020 Adam Chalkley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
 
 ## References
 
-- <https://github.com/WhyAskWhy/mysql2sqlite-dev>
-- <https://github.com/WhyAskWhy/mysql2sqlite>
+Various references used when developing this project can be found in our
+[references](docs/references.md) doc.
 
-- <https://github.com/go-sql-driver/mysql#usage>
-- <https://github.com/go-sql-driver/mysql#timetime-support>
-- <https://github.com/joho/sqltocsv>
-  - <https://github.com/joho/sqltocsv/blob/5650f27fd5b64a3806f6251308cba1a4d5ec598d/sqltocsv.go#L123-L159>
+<!-- Footnotes here  -->
 
-- <https://www.sqlite.org/datatype3.html>
-- <https://www.sqlite.org/lang_createindex.html>
+[repo-url]: <https://github.com/atc0005/mysql2sqlite>  "This project's GitHub repo"
 
-- Get row count for table
-  - <https://gist.github.com/trkrameshkumar/f4f1c00ef5d578561c96>
-  - <https://gist.github.com/agis/7e8cd4c7a20d037c01e663402fcad9d0>
+[go-docs-download]: <https://golang.org/dl>  "Download Go"
+
+[go-docs-install]: <https://golang.org/doc/install>  "Install Go"
+
+<!-- []: PLACEHOLDER "DESCRIPTION_HERE" -->

--- a/cmd/check_mysql2sqlite/main.go
+++ b/cmd/check_mysql2sqlite/main.go
@@ -192,6 +192,7 @@ func main() {
 		// https://github.com/mattn/go-sqlite3/issues/209
 		//
 		// TODO: (GH-10) Add config file setting for specifying the journal mode.
+		// TODO: (GH-35) Add config file setting for specifying busy timeout
 		//
 		"%s?_journal_mode=%s&_busy_timeout=1000",
 		sqliteDBFile,

--- a/cmd/mysql2sqlite/main.go
+++ b/cmd/mysql2sqlite/main.go
@@ -126,6 +126,7 @@ func main() {
 		// https://github.com/mattn/go-sqlite3/issues/209
 		//
 		// TODO: (GH-10) Add config file setting for specifying the journal mode.
+		// TODO: (GH-35) Add config file setting for specifying busy timeout
 		//
 		"%s?_journal_mode=%s&_busy_timeout=1000",
 		sqliteDBFile,

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -69,3 +69,6 @@ before deployment.
 - logrotate
   - <https://github.com/logrotate/logrotate>
   - <http://manpages.ubuntu.com/manpages/man8/logrotate.8.html>
+
+- Nagios
+  - <https://nagios-plugins.org/doc/guidelines.html>

--- a/contrib/mysql2sqlite/config.example.yaml
+++ b/contrib/mysql2sqlite/config.example.yaml
@@ -30,25 +30,26 @@ mysql_config:
   # If specific columns are sensitive and you do not wish to mirror the field
   # values to the SQLite database, provide a placeholder value in the defined
   # SELECT statements in this file (e.g., 'NULL').
-  username: mysql2sqlite
+  username: ""
 
   # Password for the MySQL database account. Read-only access is sufficient.
-  password: qwerty
+  password: ""
 
   # MySQL database host. If you use a stunnel or other forwarded connection
   # you will likely wish to set this to 127.0.0.1 and override the default
   # port setting.
-  host: 127.0.0.1
+  host: ""
 
-  # If this script runs on the same box as the MySQL/MariaDB server then you
-  # probably want to enter 3306 here, otherwise if using stunnel or another
-  # port forwarding setup you will likely need to enter an alternate port.
+  # If the applications from this project run on the same box as the
+  # MySQL/MariaDB server then you probably want to enter 3306 here, otherwise
+  # if using stunnel or another port forwarding setup you will likely need to
+  # enter an alternate port.
   port: 3306
 
-  # The database whose contents you wish to mirror to a local SQLite database
+  # The database whose contents you wish to mirror to a local SQLite database.
   # Note: make sure to update the queries in this file to reflect the schema
   # for this database.
-  database: mailserver
+  database: ""
 
   # Driver-specific TLS connection settings.
   # https://github.com/go-sql-driver/mysql#tls
@@ -69,9 +70,11 @@ mysql_config:
   # Specified in minutes.
   max_connection_lifetime: 3
 
-  # Maximum number of connections to the MySQL allowed for this application.
+  # Maximum number of connections allowed to the source MySQL database for
+  # this application.
   max_open_connections: 10
 
+  # Maximum number of idle connections allowed to the source MySQL database.
   # Recommended to be set the same (or greater than) max_open_connections.
   max_idle_connections: 10
 

--- a/doc.go
+++ b/doc.go
@@ -1,7 +1,7 @@
 /*
 
 This repo contains various tools used to mirror MySQL database tables to
-a local SQLite and validate the results.
+a local SQLite database and validate the results.
 
 
 PROJECT HOME

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,71 @@
+<!-- omit in toc -->
+# mysql2sqlite: Building
+
+- [Project README](../README.md)
+
+<!-- omit in toc -->
+## Table of contents
+
+- [Build source code](#build-source-code)
+- [Optional: Use existing binaries](#optional-use-existing-binaries)
+
+## Build source code
+
+1. [Download][go-docs-download] Go
+1. [Install][go-docs-install] Go
+   - NOTE: Pay special attention to the remarks about `$HOME/.profile`
+1. Clone the repo
+   1. `cd /tmp`
+   1. `git clone https://github.com/atc0005/mysql2sqlite`
+   1. `cd mysql2sqlite`
+1. Install dependencies
+   - for Ubuntu Linux
+     - `sudo apt-get install make gcc`
+   - for CentOS Linux
+     - `sudo yum install make gcc`
+   - for Windows
+     - Emulated environments (*easier*)
+       - Skip all of this and build using the default `go build` command in
+         Windows (see below for use of the `-mod=vendor` flag)
+       - build using Windows Subsystem for Linux Ubuntu environment and just
+         copy out the Windows binaries from that environment
+       - If already running a Docker environment, use a container with the Go
+         tool-chain already installed
+       - If already familiar with LXD, create a container and follow the
+         installation steps given previously to install required dependencies
+     - Native tooling (*harder*)
+       - see the StackOverflow Question `32127524` link in the
+         [References](references.md) section for potential options for
+         installing `make` on Windows
+       - see the mingw-w64 project homepage link in the
+         [References](references.md) section for options for installing `gcc`
+         and related packages on Windows
+1. Build binaries
+   - for the current operating system, explicitly using bundled dependencies
+         in top-level `vendor` folder
+     - `go build -mod=vendor ./cmd/check_mysql2sqlite/`
+     - `go build -mod=vendor ./cmd/mysql2sqlite/`
+   - for all supported platforms (where `make` is installed)
+      - `make all`
+   - for use on Windows
+      - `make windows`
+   - for use on Linux
+     - `make linux`
+1. Locate the newly compiled binaries from the applicable `/tmp` subdirectory
+   path.
+   - if using `Makefile`
+     - look in `/tmp/mysql2sqlite/release_assets/check_mysql2sqlite/`
+     - look in `/tmp/mysql2sqlite/release_assets/mysql2sqlite/`
+   - if using `go build`
+     - look in `/tmp/mysql2sqlite/`
+
+See the [deploy](deploy.md) doc for instructions for how to deploy the newly
+generated binaries.
+
+## Optional: Use existing binaries
+
+As an alternative to building the binaries yourself, this project also
+periodically provides binaries as part of new releases. If binaries for your
+platform are not provided, please [file an
+issue](https://github.com/atc0005/mysql2sqlite/issues/new) so that we may
+evaluate the requirements for providing those binaries with future releases.

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -1,0 +1,147 @@
+<!-- omit in toc -->
+# mysql2sqlite: Configuration
+
+- [Project README](../README.md)
+
+<!-- omit in toc -->
+## Table of contents
+
+- [Precedence](#precedence)
+- [Command-line Arguments](#command-line-arguments)
+- [Environment Variables](#environment-variables)
+- [Configuration File](#configuration-file)
+  - [Settings](#settings)
+  - [Starter/Example file](#starterexample-file)
+- [Worth noting](#worth-noting)
+  - [Automatic config file detection](#automatic-config-file-detection)
+  - [Log formats](#log-formats)
+
+## Precedence
+
+The priority order is:
+
+1. Command line flags (highest priority)
+1. Environment variables
+1. Configuration file
+1. Default settings (lowest priority)
+
+A limited number of options are supported via command-line flags or
+environment variables in order to "bootstrap" the applications provided by
+this project. A configuration file is required to set all other required
+values.
+
+To be clear, it is not possible to use the applications provided by this
+project without supplying a configuration file. A [starter config
+file](../contrib/README.md) is provided, but it will need to be modified
+before it will be useful.
+
+## Command-line Arguments
+
+- Flags marked as **`required`** must be set via CLI flag *or* within the
+  YAML-formatted configuration file.
+- Flags *not* marked as required are for settings where a useful default is
+  already defined.
+
+| Option        | Required                 | Default        | Repeat | Possible                                   | Description                                                                                                                      |
+| ------------- | ------------------------ | -------------- | ------ | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `h`, `help`   | No                       | `false`        | No     | `h`, `help`                                | Show Help text along with the list of supported flags.                                                                           |
+| `config-file` | [*Maybe*](#worth-noting) | *empty string* | No     | *valid path to a file*                     | Fully-qualified path to a configuration file consulted for settings not already provided via CLI flags or environment variables. |
+| `log-level`   | No                       | `info`         | No     | `fatal`, `error`, `warn`, `info`, `debug`  | Log message priority filter. Log messages with a lower level are ignored.                                                        |
+| `log-output`  | No                       | `stdout`       | No     | `stdout`, `stderr`                         | Log messages are written to this output target.                                                                                  |
+| `log-format`  | No                       | `text`         | No     | `cli`, `json`, `logfmt`, `text`, `discard` | Use the specified `apex/log` package "handler" to output log messages in that handler's format.                                  |
+
+## Environment Variables
+
+If set, environment variables override settings provided by a configuration
+file. If used, command-line arguments override the equivalent environment
+variables listed below. See the [Command-line
+Arguments](#command-line-arguments) table for more information.
+
+| Flag Name     | Environment Variable Name  | Notes | Example (mostly using default values)                                |
+| ------------- | -------------------------- | ----- | -------------------------------------------------------------------- |
+| `config-file` | `MYSQL2SQLITE_CONFIG_FILE` |       | `MYSQL2SQLITE_CONFIG_FILE="/usr/local/etc/mysql2sqlite/config.yaml"` |
+| `log-level`   | `MYSQL2SQLITE_LOG_LEVEL`   |       | `MYSQL2SQLITE_LOG_LEVEL="info"`                                      |
+| `log-output`  | `MYSQL2SQLITE_LOG_OUTPUT`  |       | `MYSQL2SQLITE_LOG_OUTPUT="stdout"`                                   |
+| `log-format`  | `MYSQL2SQLITE_LOG_FORMAT`  |       | `MYSQL2SQLITE_LOG_FORMAT="text"`                                     |
+
+## Configuration File
+
+### Settings
+
+Configuration file settings have the lowest priority and are overridden by
+settings specified in other configuration sources, except for default values.
+See the [Command-line Arguments](#command-line-arguments) table for more
+information, including the available values for the listed configuration
+settings.
+
+| Flag Name    | Config file Setting Name           | Section Name    | Default                   | Possible                                                              | Description                                                                                                                                                                                                                                   | Notes                                              |
+| ------------ | ---------------------------------- | --------------- | ------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `log-level`  | `level`                            | `logging`       | `info`                    | `fatal`, `error`, `warn`, `info`, `debug`                             | See flag description                                                                                                                                                                                                                          |                                                    |
+| `log-format` | `format`                           | `logging`       | `text`                    | `cli`, `json`, `logfmt`, `text`, `discard`                            | See flag description                                                                                                                                                                                                                          |                                                    |
+| `log-output` | `output`                           | `logging`       | `stdout`                  | `stdout`, `stderr`                                                    | See flag description                                                                                                                                                                                                                          |                                                    |
+| N/A          | `connection_stats`                 | `logging`       | `false`                   | `true`, `false`                                                       | Whether connection statistics are logged during application execution. This can be useful for troubleshooting, but is probably too much information for normal operation.                                                                     |                                                    |
+| N/A          | `trim_leading_trailing_whitespace` | `general`       | `false`                   | `true`, `false`                                                       | If enabled, this setting trims all leading and trailing whitespace from values retrieved from the MySQL database before writing to the SQLite database.                                                                                       |                                                    |
+| N/A          | `connection_retries`               | `general`       | `5`                       | *number of retries as a valid whole number*                           | The number of times a connection should be retried before giving up and returning an error.                                                                                                                                                   |                                                    |
+| N/A          | `connection_retry_delay`           | `general`       | `2`                       | *number of seconds as a whole number*                                 | The number of seconds between connection retry attempts.                                                                                                                                                                                      |                                                    |
+| N/A          | `connection_timeout`               | `general`       | `15`                      | *number of seconds as a whole number*                                 | The number of seconds a connection should be tried before giving up and returning an error.                                                                                                                                                   |                                                    |
+| N/A          | `username`                         | `mysql_config`  | *empty string*            | *valid MySQL user account name with sufficient access to database*    | MySQL user account name with sufficient access to database.                                                                                                                                                                                   |                                                    |
+| N/A          | `password`                         | `mysql_config`  | *empty string*            | *valid MySQL user account password for account used to read database* | Password for the MySQL database account. Read-only access is sufficient.                                                                                                                                                                      |                                                    |
+| N/A          | `host`                             | `mysql_config`  | *empty string*            | *valid fqdn or IP Address*                                            | MySQL database host. If you use a stunnel or other forwarded connection you will likely wish to set this to 127.0.0.1 and override the default port setting.                                                                                  |                                                    |
+| N/A          | `port`                             | `mysql_config`  | `3306`                    | *valid TCP port number*                                               | If the applications from this project run on the same box as the MySQL/MariaDB server then you probably want to enter 3306 here, otherwise if using stunnel or another port forwarding setup you will likely need to enter an alternate port. |                                                    |
+| N/A          | `database`                         | `mysql_config`  | *empty string*            | *valid MySQL database name*                                           | The database whose contents you wish to mirror to a local SQLite database.                                                                                                                                                                    |                                                    |
+| N/A          | `encryption`                       | `mysql_config`  | `preferred`               | `true`, `false`, `skip-verify`, `preferred`                           | Driver-specific TLS connection settings.                                                                                                                                                                                                      | [Docs](https://github.com/go-sql-driver/mysql#tls) |
+| N/A          | `max_connection_lifetime`          | `mysql_config`  | `3`                       | *number of minutes as a whole number*                                 | Maximum connection lifetime.                                                                                                                                                                                                                  |                                                    |
+| N/A          | `max_open_connections`             | `mysql_config`  | `10`                      | *valid whole number less than maximum allowed by remote db host*      | Maximum number of connections allowed to the source MySQL database for this application.                                                                                                                                                      |                                                    |
+| N/A          | `max_idle_connections`             | `mysql_config`  | `10`                      | *valid whole number less than maximum allowed by remote db host*      | Maximum number of idle connections allowed to the source MySQL database. Recommended to be set the same (or greater than) max_open_connections.                                                                                               |                                                    |
+| N/A          | `db_filename`                      | `sqlite_config` | `mailserver.db`           | *valid, non-qualified filename*                                       | The "short" name of the SQLite database file. Do not specify the directory which will hold the file here.                                                                                                                                     |                                                    |
+| N/A          | `base_dir`                         | `sqlite_config` | `/var/cache/mysql2sqlite` | *valid, qualified directory name*                                     | The directory that will hold the SQLite database file. The user running this script should have write access to this location. Make sure that applicable daemons (e.g., Postfix, Dovecot, etc) have read access to the file.                  |                                                    |
+| N/A          | `create_indexes`                   | `sqlite_config` | `false`                   | `true`, `false`                                                       | Whether an "index" query will be required for each table query set defined within this file. If enabled, this application will use the "index" query to generate indexes when creating tables in the SQLite database file.                    |                                                    |
+
+### Starter/Example file
+
+The [`config.example.yaml`](../contrib/README.md) file is provided as a
+starting point for your own configuration file. The default values provided by
+this configuration file should lineup with the default application values if
+not specified. Please [file an
+issue](https://github.com/atc0005/mysql2sqlite/issues/new) if you find that is
+not the case.
+
+Once modified, your copy of the configuration file can be placed in a location
+of your choosing and referenced using the `--config-file` flag. See the
+[Command-line arguments](#command-line-arguments) sections for usage details.
+
+If the file cannot be located, the application will note this and then abort.
+
+## Worth noting
+
+### Automatic config file detection
+
+If not specified, applications provided by this project will attempt to
+automatically locate the configuration file by looking in the following
+locations:
+
+1. user-specified path to config file
+   - e.g., `/usr/local/etc/mysql2sqlite/config.yaml`
+   - e.g., `C:\mysql2sqlite\config.yaml`
+1. config file found alongside the executable
+   - e.g., `/home/username/Desktop/mysql2sqlite/config.yaml`
+1. config file found in the user's configuration path
+   - e.g., `/home/username/.config/mysql2sqlite/config.yaml`
+   - e.g., `C:\Users\username\AppData\Roaming\mysql2sqlite\config.yaml`
+
+If the file cannot be located, the application will note this and then abort.
+
+### Log formats
+
+Log format names map directly to the Handlers provided by the `apex/log`
+package. Their descriptions are copied from the [official
+README](https://github.com/apex/log/blob/master/Readme.md) and provided below
+for reference:
+
+| Log Format ("Handler") | Description                        |
+| ---------------------- | ---------------------------------- |
+| `cli`                  | human-friendly CLI output          |
+| `json`                 | provides log output in JSON format |
+| `logfmt`               | plain-text logfmt output           |
+| `text`                 | human-friendly colored output      |
+| `discard`              | discards all logs                  |

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,228 @@
+<!-- omit in toc -->
+# mysql2sqlite: Deployment
+
+- [Project README](../README.md)
+
+<!-- omit in toc -->
+## Table of contents
+
+- [Overview](#overview)
+- [Assumptions](#assumptions)
+- [Privileges required](#privileges-required)
+  - [Service accounts](#service-accounts)
+  - [Ownership / permissions](#ownership--permissions)
+- [Directions](#directions)
+  - [Create service account and group](#create-service-account-and-group)
+  - [Add existing service accounts to new group](#add-existing-service-accounts-to-new-group)
+  - [Prepare SQLite database cache](#prepare-sqlite-database-cache)
+  - [Prepare log directory, files](#prepare-log-directory-files)
+  - [Deploy binaries](#deploy-binaries)
+  - [Deploy configuration file](#deploy-configuration-file)
+  - [Deploy wrapper scripts](#deploy-wrapper-scripts)
+  - [Deploy sudoers config fragment](#deploy-sudoers-config-fragment)
+  - [Deploy logrotate config fragment](#deploy-logrotate-config-fragment)
+  - [Deploy cron config fragment](#deploy-cron-config-fragment)
+  - [Deploy Nagios "client" configuration file](#deploy-nagios-client-configuration-file)
+
+## Overview
+
+While you can run the `mysql2sqlite` binary directly as a one-off
+synchronization job, the most common use case will be running the
+`mysql2sqlite` binary from a cron job and the `check_mysql2sqlite` binary via
+the Nagios Remote Plugin Executor (`NRPE`).
+
+This deployment document walks you through deploying both applications
+provided by this project in order to synchronize a remote MySQL database named
+`mailserver` will be synchronized to a local SQLite database of the same
+overall name: `mailserver.db`.
+
+In our example, this database is used by Postfix for various lookup tables as
+part of its normal operation. Substitute this database filename for whatever
+database you wish to generate/maintain using `mysql2sqlite`.
+
+## Assumptions
+
+Various assumptions are made in this documentation. These assumptions are made
+in order to provide a more complete example that illustrates how binaries
+provided by this project may be used. Modify as you feel appropriate.
+
+## Privileges required
+
+These directions illustrate creating a "service account" to run the
+`mysql2sqlite` application as a dedicated user. This application does not have
+complex requirements and does not require elevated privileges; running as the
+root user account is not needed nor advised.
+
+### Service accounts
+
+These directions also assume that the `postfix` service account will need to
+read this database and uses its membership in the `mysql2sqlite` group to
+accomplish this. Substitute this also by specifying the name of an applicable
+service account that will need to access the SQLite database file that you
+generate.
+
+### Ownership / permissions
+
+The `mysql2sqlite` service account is used to run the `mysql2sqlite` binary
+from a cron job in order to regenerate a local SQLite database. This service
+account requires read/write access to the SQLite database and the cron log
+file.
+
+A wrapper script is used to run the `check_mysql2sqlite` Nagios plugin in
+order to validate that the local database matches the remote database. Only
+when there is a discrepancy is the `mysql2sqlite` binary run to synchronize
+both databases.
+
+All output is captured and redirected with desired log output going to a
+dedicated "cron" log file.
+
+The `nagios` (or `nrpe`) service account is used to run the
+`check_mysql2sqlite` binary from the Nagios Remote Plugin Executor (`NRPE`) in
+order to validate the local SQLite database against the source MySQL database.
+
+This plugin is also run via a wrapper script. When run, a specific flag is
+passed that directs log output to `stderr` which the wrapper script redirects
+to a "nagios" log file specific to the plugin. `stdout` output is not
+redirected, passing on to the Nagios Remote Plugin Executor (`NRPE`) and back
+to the Nagios console which initiated the check.
+
+## Directions
+
+### Create service account and group
+
+1. `sudo useradd mysql2sqlite --system --shell /usr/sbin/nologin --user-group`
+1. `echo "mysql2sqlite:$(python3 -c 'import uuid; print(uuid.uuid4())')" | sudo chpasswd`
+   - this is optional and dependent upon a system installation of Python 3
+   - replace `python3` with `python` if applicable
+
+### Add existing service accounts to new group
+
+For this example, we'll assume that these user accounts exist:
+
+| Software                               | User Account | Notes        |
+| -------------------------------------- | ------------ | ------------ |
+| Postfix                                | `postfix`    |              |
+| Nagios Remote Plugin Executor (`NRPE`) | `nagios`     | Debian-based |
+| Nagios Remote Plugin Executor (`NRPE`) | `nrpe`       | RedHat-based |
+
+1. `sudo usermod --groups mysql2sqlite postfix`
+1. `sudo usermod --groups mysql2sqlite nagios`
+   - substitute with `nrpe` if applicable
+
+### Prepare SQLite database cache
+
+This sets up the directory to hold the database and creates a placeholder file
+with the desired permissions.
+
+1. `sudo mkdir -vp /var/cache/mysql2sqlite`
+1. `sudo touch /var/cache/mysql2sqlite/mailserver.db`
+1. `sudo chown -Rv mysql2sqlite:mysql2sqlite /var/cache/mysql2sqlite`
+1. `sudo chmod -v 2750 /var/cache/mysql2sqlite`
+   - this enables `setgid` in order to allow the `mysql2sqlite` group to be
+     inherited for any content created within this path
+1. `sudo chmod -v 0640 /var/cache/mysql2sqlite/mailserver.db`
+
+### Prepare log directory, files
+
+This sets up the log directory and creates placeholder log files with the
+desired permissions.
+
+1. Create directory, placeholder files
+   1. `sudo mkdir -vp /var/log/mysql2sqlite`
+   1. `sudo touch /var/log/mysql2sqlite/nagios.log`
+   1. `sudo touch /var/log/mysql2sqlite/cron.log`
+1. Set ownership, permissions
+   1. `sudo chown -Rv mysql2sqlite:mysql2sqlite /var/log/mysql2sqlite`
+   1. `sudo chmod -v 0660 /var/log/mysql2sqlite/nagios.log`
+      - the `nagios` or `nrpe` service account is a member of the
+        `mysql2sqlite` group
+   1. `sudo chmod -v 0640 /var/log/mysql2sqlite/cron.log`
+
+### Deploy binaries
+
+Continuing where the [build](build.md) instructions left off, follow the steps
+below to deploy the generated `check_mysql2sqlite` and `mysql2sqlite` binaries
+to locations on a system that will run them.
+
+1. Deploy `check_mysql2sqlite`
+   - as `/usr/lib/nagios/plugins/check_mysql2sqlite` on Debian-based systems
+   - as `/usr/lib64/nagios/plugins/check_mysql2sqlite` on RedHat-based systems
+     - note: don't forget about SELinux contexts!
+1. Deploy `mysql2sqlite`
+   - as `/usr/local/sbin/mysql2sqlite`
+1. Set execute bit on `mysql2sqlite` binary
+   1. `sudo chmod -v +x /usr/local/sbin/mysql2sqlite`
+1. Set execute bit on `check_mysql2sqlite` binary
+   - `sudo chmod -v +x /usr/lib/nagios/plugins/check_mysql2sqlite`
+   - `sudo chmod -v +x /usr/lib64/nagios/plugins/check_mysql2sqlite`
+
+### Deploy configuration file
+
+This sets up a directory to hold the `mysql2sqlite` and `check_mysql2sqlite`
+configuration file, copies the file and sets permissions to prevent casual
+read access to the file.
+
+1. Create directory
+   1. `sudo mkdir -vp /usr/local/etc/mysql2sqlite`
+1. Deploy configuration file
+   - template: `contrib/mysql2sqlite/config.example.yaml`
+   - destination: `/usr/local/etc/mysql2sqlite/config.yaml`
+1. Modify configuration file
+   - see [configure](configure.md) doc for details
+1. Set ownership, permissions
+   1. `sudo chown -v root:mysql2sqlite
+      /usr/local/etc/mysql2sqlite/config.yaml`
+   1. `sudo chmod -v 0640 /usr/local/etc/mysql2sqlite/config.yaml`
+   - this file contains username/password pair, so it is important to restrict
+     access to only user/groups that need to use it
+
+### Deploy wrapper scripts
+
+1. Deploy `mysql2sqlite_wrapper.sh`
+   - as `/usr/local/sbin/mysql2sqlite_wrapper.sh`
+1. Deploy `check_mysql2sqlite_wrapper.sh`
+   - as `/usr/local/sbin/check_mysql2sqlite_wrapper.sh`
+1. Set ownership, permissions
+   1. `sudo chown -v root:root /usr/local/sbin/mysql2sqlite_wrapper.sh`
+   1. `sudo chmod -v +x /usr/local/sbin/mysql2sqlite_wrapper.sh`
+   1. `sudo chown -v root:root /usr/local/sbin/check_mysql2sqlite_wrapper.sh`
+   1. `sudo chmod -v +x /usr/local/sbin/check_mysql2sqlite_wrapper.sh`
+
+### Deploy sudoers config fragment
+
+1. Deploy `sudoers.d/mysql2sqlite`
+   - as `/etc/sudoers.d/mysql2sqlite`
+1. Set ownership, permissions
+   1. `sudo chown -v root:root /etc/sudoers.d/mysql2sqlite`
+   1. `sudo chmod -v 0400 /etc/sudoers.d/mysql2sqlite`
+
+### Deploy logrotate config fragment
+
+1. Deploy `logrotate.d/mysql2sqlite`
+   - as `/etc/logrotate.d/mysql2sqlite`
+1. Set ownership, permissions
+   1. `sudo chown -v root:root /etc/logrotate.d/mysql2sqlite`
+   1. `sudo chmod -v 644 /etc/logrotate.d/mysql2sqlite`
+
+### Deploy cron config fragment
+
+1. Deploy `cron.d/mysql2sqlite`
+   - as `/etc/cron.d/mysql2sqlite`
+1. Set ownership, permissions
+   1. `sudo chown -v root:root /etc/cron.d/mysql2sqlite`
+   1. `sudo chmod -v 644 /etc/cron.d/mysql2sqlite`
+
+### Deploy Nagios "client" configuration file
+
+The Nagios Remote Plugin Executor (`NRPE`) configuration fragment is deployed
+to the same system where the `mysql2sqlite` and `check_mysql2sqlite` binaries
+will be executed.
+
+1. Deploy `nagios/nrpe.d/mysql2sqlite.cfg`
+   - as `/etc/nagios/nrpe.d/mysql2sqlite.cfg`
+1. Set ownership, permissions
+   1. `sudo chown -v root:root /etc/nagios/nrpe.d/mysql2sqlite.cfg`
+   1. `sudo chmod -v 644 /etc/nagios/nrpe.d/mysql2sqlite.cfg`
+1. Restart the `nrpe` daemon
+   - Debian-based: `sudo service nagios-nrpe-server restart`
+   - RedHat-based: `sudo service nrpe restart`

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,0 +1,87 @@
+<!-- omit in toc -->
+# mysql2sqlite: References
+
+- [Project README](../README.md)
+
+<!-- omit in toc -->
+## Table of contents
+
+- [Overview](#overview)
+- [References](#references)
+  - [External](#external)
+  - [Dependencies](#dependencies)
+  - [Instruction / Examples](#instruction--examples)
+  - [Related projects](#related-projects)
+
+## Overview
+
+The links below are for resources that were found to be useful (if not
+absolutely essential) while developing this application.
+
+## References
+
+### External
+
+- Nagios
+  - <https://nagios-plugins.org/doc/guidelines.html>
+
+- Cron
+  - <http://manpages.ubuntu.com/manpages/man5/crontab.5.html>
+
+- Postfix
+  - <http://www.postfix.org/DATABASE_README.html>
+  - <http://www.postfix.org/sqlite_table.5.html>
+  - <https://workaround.org/ispmail>
+
+- logrotate
+  - <https://github.com/logrotate/logrotate>
+  - <http://manpages.ubuntu.com/manpages/man8/logrotate.8.html>
+
+### Dependencies
+
+- `make` on Windows
+  - <https://stackoverflow.com/questions/32127524/how-to-install-and-use-make-in-windows>
+- `gcc` on Windows
+  - <https://en.wikipedia.org/wiki/MinGW>
+  - <http://mingw-w64.org/>
+  - <https://www.msys2.org/>
+
+- Libraries/packages
+  - Configuration
+    - <https://github.com/alexflint/go-arg>
+    - <https://github.com/go-yaml/yaml>
+  - Logging
+    - <https://github.com/apex/log>
+  - Go database drivers (see also `go.mod`)
+    - <https://github.com/go-sql-driver/mysql>
+    - <https://github.com/mattn/go-sqlite3>
+
+### Instruction / Examples
+
+- <https://github.com/WhyAskWhy/mysql2sqlite-dev>
+- <https://github.com/WhyAskWhy/mysql2sqlite>
+- <https://github.com/joho/sqltocsv>
+  - <https://github.com/joho/sqltocsv/blob/5650f27fd5b64a3806f6251308cba1a4d5ec598d/sqltocsv.go#L123-L159>
+
+- SQLite
+  - <https://www.sqlite.org/datatype3.html>
+  - <https://www.sqlite.org/lang_createindex.html>
+  - <https://dba.stackexchange.com/questions/45368/how-do-i-prevent-sqlite-database-locks>
+  - <https://manski.net/2012/10/sqlite-performance/>
+  - <https://www.sqlite.org/wal.html>
+  - <https://www.sqlite.org/pragma.html#pragma_journal_mode>
+  - <https://www.sqlite.org/pragma.html#pragma_busy_timeout>
+  - <https://github.com/mattn/go-sqlite3/pull/827>
+  - <https://github.com/mattn/go-sqlite3/issues/209>
+
+- Get row count for table
+  - <https://gist.github.com/trkrameshkumar/f4f1c00ef5d578561c96>
+  - <https://gist.github.com/agis/7e8cd4c7a20d037c01e663402fcad9d0>
+
+- Nagios
+  - <https://github.com/atc0005/go-nagios>
+  - <https://nagios-plugins.org/doc/guidelines.html>
+
+### Related projects
+
+- <https://github.com/atc0005/go-nagios>


### PR DESCRIPTION
By "story", I refer to the real-world use case provided by the `contrib` content and this updated documentation.

By providing a specific deployment scenario, the hope is that this application's usage will be made clearer. Further refinements to the directions are expected. This should be considered a first draft submitted for review in order to collect feedback.

- fixes GH-13
- fixes GH-17