### PR TITLE
Fix error in MySQL test data insert statement

### DIFF
--- a/contrib/mailserver/sql/mysql_test_data.sql
+++ b/contrib/mailserver/sql/mysql_test_data.sql
@@ -19,10 +19,10 @@
 --    problematic data.
 
 INSERT INTO `mailserver`.`virtual_domains`
-  (`id` ,`name`)
+  (`id`, `name`, `ticket_number`)
 VALUES
-  ('1', 'example.com'),
-  ('2', 'example.net')
+  ('1', 'example.com', 12345),
+  ('2', 'example.net', 12345)
 ;
 
 


### PR DESCRIPTION
Add required `ticket_number` field value for for `virtual_domains` table. Evidently MariaDB 10.x doesn't mind this omission, but later versions appear to correctly handle the issue (and refuse to continue with the insert with missing data).

fixes GH-52