### PR TITLE
Disable printing Go version provided by GHAWs VM

### DIFF
--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -127,8 +127,12 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - name: Print go version
-        run: go version
+      # This doesn't apply here; were we to execute this, it would show us the
+      # Go version provided by the GitHub Actions environment (VM) and not our
+      # Docker images.
+      #
+      # - name: Print go version
+      #   run: go version
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2.3.3


### PR DESCRIPTION
When reviewing the latest Actions results I saw that Go 1.14.9 was "used" by the "Build static binaries using Docker images" job. This initially confused me until I realized that this was emitted from within the GitHub Actions virtual machine environment and not from within the Docker containers used for the job.

This commit disables printing that information and notes why in an effort to reduce confusion going forward.