### PR TITLE
Increase golangci-lint timeout from 1m default

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -35,7 +35,7 @@ jobs:
           rm -vf .golangci.yml
 
       - name: Run golangci-lint using container-provided config file settings
-        run: golangci-lint run -v
+        run: golangci-lint run -v --timeout 2m
 
       # This is the very latest stable version of staticcheck provided by the
       # atc0005/go-ci container. The version included with golangci-lint often

--- a/.github/workflows/lint-and-test-only.yml
+++ b/.github/workflows/lint-and-test-only.yml
@@ -33,7 +33,7 @@ jobs:
           rm -vf .golangci.yml
 
       - name: Run golangci-lint using container-provided config file settings
-        run: golangci-lint run -v
+        run: golangci-lint run -v --timeout 2m
 
       - name: Run all tests
         run: go test -mod=vendor -v ./...


### PR DESCRIPTION
Double timeout value from default 1 minute value to work around context timeout. I expect that this is either related to a temporary issue with GH or with the new Go 1.16 release that is now used as the container for golangci-lint tasks.

fixes GH-80
