### PR TITLE
Add missing log.Errorf() parameter

### DIFF
--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -38,6 +38,7 @@ func (c *Config) loadConfigFile(configFile string) (bool, error) {
 			if !errors.Is(err, os.ErrClosed) {
 				log.Errorf(
 					"loadConfigFile: failed to close file %q: %s",
+					configFile,
 					err.Error(),
 				)
 			}


### PR DESCRIPTION
Visually found this one, not caught by current linters.