### PR TITLE
Add tests to assert presence of custom flags

### DIFF
--- a/cmd/check_mysql2sqlite/main_test.go
+++ b/cmd/check_mysql2sqlite/main_test.go
@@ -1,0 +1,47 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/mysql2sqlite
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/atc0005/mysql2sqlite/internal/config"
+)
+
+// Setup basic tests to ensure that alexflint/go-arg package recognizes flags
+// (see atc0005/query-meta#15 and alexflint/go-arg#157 for backstory) and that
+// config file loading works as expected.
+
+func TestFlagsParsing(t *testing.T) {
+
+	// https://stackoverflow.com/questions/33723300/how-to-test-the-passing-of-arguments-in-golang
+
+	// Save old command-line arguments so that we can restore them later
+	oldArgs := os.Args
+
+	// Defer restoring original command-line arguments
+	defer func() { os.Args = oldArgs }()
+
+	// Note to self: Don't add/escape double-quotes here. The shell strips
+	// them away and the application never sees them.
+	os.Args = []string{
+		"/usr/lib/nagios/plugins/check_mysql2sqlite",
+		"--config-file", "../../contrib/mysql2sqlite/config.example.yaml",
+		"--log-format", "logfmt",
+		"--log-output", "stderr",
+	}
+
+	_, err := config.NewConfig()
+	if err != nil {
+		t.Errorf("Error encountered when instantiating configuration: %s", err)
+	} else {
+		t.Log("No errors encountered when instantiating configuration")
+	}
+
+}

--- a/cmd/mysql2sqlite/main_test.go
+++ b/cmd/mysql2sqlite/main_test.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/mysql2sqlite
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/atc0005/mysql2sqlite/internal/config"
+)
+
+// Setup basic tests to ensure that alexflint/go-arg package recognizes flags
+// (see atc0005/query-meta#15 and alexflint/go-arg#157 for backstory) and that
+// config file loading works as expected.
+
+func TestFlagsParsing(t *testing.T) {
+
+	// https://stackoverflow.com/questions/33723300/how-to-test-the-passing-of-arguments-in-golang
+
+	// Save old command-line arguments so that we can restore them later
+	oldArgs := os.Args
+
+	// Defer restoring original command-line arguments
+	defer func() { os.Args = oldArgs }()
+
+	// Note to self: Don't add/escape double-quotes here. The shell strips
+	// them away and the application never sees them.
+	os.Args = []string{
+		"/usr/local/sbin/mysql2sqlite",
+		"--config-file", "../../contrib/mysql2sqlite/config.example.yaml",
+		"--log-format", "logfmt",
+	}
+
+	_, err := config.NewConfig()
+	if err != nil {
+		t.Errorf("Error encountered when instantiating configuration: %s", err)
+	} else {
+		t.Log("No errors encountered when instantiating configuration")
+	}
+
+}

--- a/contrib/mysql2sqlite/config.example.yaml
+++ b/contrib/mysql2sqlite/config.example.yaml
@@ -30,15 +30,15 @@ mysql_config:
   # If specific columns are sensitive and you do not wish to mirror the field
   # values to the SQLite database, provide a placeholder value in the defined
   # SELECT statements in this file (e.g., 'NULL').
-  username: ""
+  username: "PLACEHOLDER"
 
   # Password for the MySQL database account. Read-only access is sufficient.
-  password: ""
+  password: "PLACEHOLDER"
 
   # MySQL database host. If you use a stunnel or other forwarded connection
   # you will likely wish to set this to 127.0.0.1 and override the default
   # port setting.
-  host: ""
+  host: "PLACEHOLDER"
 
   # If the applications from this project run on the same box as the
   # MySQL/MariaDB server then you probably want to enter 3306 here, otherwise


### PR DESCRIPTION
Provides tests for the main `mysql2sqlite` binary along
and the `check_mysql2sqlite` Nagios plugin.

Tests performed:

- assert that custom flags are recognized
- assert that config file is parsed and passes config validation

This required inserting `PLACEHOLDER` values in the example
config file for username, password and database host fields.

fixes GH-89