### PR TITLE
Fix broken reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,4 @@ Various references used when developing this project can be found in our
 
 [repo-url]: <https://github.com/atc0005/mysql2sqlite>  "This project's GitHub repo"
 
-[go-docs-download]: <https://golang.org/dl>  "Download Go"
-
-[go-docs-install]: <https://golang.org/doc/install>  "Install Go"
-
 <!-- []: PLACEHOLDER "DESCRIPTION_HERE" -->

--- a/docs/build.md
+++ b/docs/build.md
@@ -82,3 +82,7 @@ periodically provides binaries as part of new releases. If binaries for your
 platform are not provided, please [file an
 issue](https://github.com/atc0005/mysql2sqlite/issues/new) so that we may
 evaluate the requirements for providing those binaries with future releases.
+
+[go-docs-download]: <https://golang.org/dl>  "Download Go"
+
+[go-docs-install]: <https://golang.org/doc/install>  "Install Go"


### PR DESCRIPTION
- Go toolchain downloads
- Go toolchain installation

The ref link labels/URLs were left behind when the build
directions were moved out of the main README file.

fixes GH-98