### PR TITLE
Fix unsafe repo error from Alpine build containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,18 +308,20 @@ docker: clean
 	docker version
 	@docker image pull $(DOCKER_BUILD_IMG_X86)
 	@docker container run \
+		--user $${UID:-1000} \
 		--rm \
 		-i \
 		-v $$PWD:$$PWD \
 		-w $$PWD \
 		$(DOCKER_BUILD_IMG_X86) \
-		make windows-x86-static linux-x86-static
+		env GOCACHE=/tmp/ make windows-x86-static linux-x86-static
 	@docker image pull $(DOCKER_BUILD_IMG_X64)
 	@docker container run \
+		--user $${UID:-1000} \
 		--rm \
 		-i \
 		-v $$PWD:$$PWD \
 		-w $$PWD \
 		$(DOCKER_BUILD_IMG_X64) \
-		make windows-x64-static linux-x64-static
+		env GOCACHE=/tmp/ make windows-x64-static linux-x64-static
 	@echo "Completed all cross-platform builds via Docker containers ..."


### PR DESCRIPTION
Resolve the `fatal: unsafe repository
('/path/to/repo' is owned by someone else)` error message
thrown by newer Git versions by:

- execute Alpine Docker build containers as non-root user
  - attempt current UID by default, fallback to trying UID 1000
- explicitly set `GOCACHE` environment variable to `/tmp/`
  within build container
  - resolve permission issue with the go toolchain attempting to
    use `/.cache` by default within the Docker container

fixes GH-159