### PR TITLE
Fix platform warning for Alpine x86 build image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,6 +308,7 @@ docker: clean
 	docker version
 	@docker image pull $(DOCKER_BUILD_IMG_X86)
 	@docker container run \
+		--platform linux/386 \
 		--user $${UID:-1000} \
 		--rm \
 		-i \
@@ -317,6 +318,7 @@ docker: clean
 		env GOCACHE=/tmp/ make windows-x86-static linux-x86-static
 	@docker image pull $(DOCKER_BUILD_IMG_X64)
 	@docker container run \
+		--platform linux/amd64 \
 		--user $${UID:-1000} \
 		--rm \
 		-i \


### PR DESCRIPTION
- specify `linux/386` platform flag value when using Alpine
  x86 build image
- explicitly specify `linux/amd64` platform flag value when
  using Alpine amd64 build image
  - no error was being emitted on the build system, but this
    could potentially be an issue later on so we explicitly
    specify the value here (for consitency if nothing else)

fixes GH-161