### PR TITLE
Remove unused "Download Go" Markdown link ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,6 @@ Various references used when developing this project can be found in our
 
 [repo-url]: <https://github.com/atc0005/mysql2sqlite>  "This project's GitHub repo"
 
-[go-docs-download]: <https://golang.org/dl>  "Download Go"
-
 [go-docs-install]: <https://golang.org/doc/install>  "Install Go"
 
 [go-supported-releases]: <https://go.dev/doc/devel/release#policy> "Go Release Policy"


### PR DESCRIPTION
Resolve markdownlint linting error by removing unused link reference.