### PR TITLE
Apply Go 1.19 specific doc comments linting fixes

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,28 +1,25 @@
 /*
-
 This repo contains various tools used to mirror MySQL database tables to
 a local SQLite database and validate the results.
 
-
-PROJECT HOME
+# PROJECT HOME
 
 See our GitHub repo (https://github.com/atc0005/mysql2sqlite) for the latest
 code, to file an issue or submit improvements for review and potential
 inclusion into the project.
 
-PURPOSE
+# PURPOSE
 
 Mirror MySQL database tables to SQLite database.
 
-FEATURES
+# FEATURES
 
-• CLI tool for mirroring MySQL database tables to SQLite database
+  - CLI tool for mirroring MySQL database tables to SQLite database
+  - Nagios plugin for validating mirrored SQLite database against the original
+    source
 
-• Nagios plugin for validating mirrored SQLite database against the original source
-
-USAGE
+# USAGE
 
 See our main README for supported settings and examples.
-
 */
 package main

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -217,7 +217,7 @@ func (c Config) MySQLMaxIdleConns() int {
 
 // MySQLConnMaxIdleTime returns the user-provided maximum time in seconds that
 // a database connection can remain idle or the default value if not provided.
-//  See also https://github.com/go-sql-driver/mysql#important-settings
+// See also https://github.com/go-sql-driver/mysql#important-settings
 func (c Config) MySQLConnMaxIdleTime() time.Duration {
 	switch {
 	case c.configFileSettings.MySQLConfig.ConnMaxIdleTime != nil:

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -40,7 +40,8 @@ const (
 	LogLevelDebug string = "debug"
 )
 
-// 	apex/log Handlers
+// apex/log Handlers
+//
 // ---------------------------------------------------------
 // cli - human-friendly CLI output
 // discard - discards all logs


### PR DESCRIPTION
These changes are effectively a NOOP for earlier Go versions, but improve the formatting of rendered documentation.