### PR TITLE
Add missing cmd doc files

### DIFF
--- a/cmd/check_mysql2sqlite/doc.go
+++ b/cmd/check_mysql2sqlite/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/mysql2sqlite
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Nagios plugin used to validate synchronization status between remote MySQL
+// and local SQLite database.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/mysql2sqlite
+package main

--- a/cmd/mysql2sqlite/doc.go
+++ b/cmd/mysql2sqlite/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/mysql2sqlite
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// CLI app used to mirror a remote MySQL database to a local SQLite database.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/mysql2sqlite
+package main


### PR DESCRIPTION
Add "package" doc file to resolve revive `package-comment` linting error surfaced by recent linter update.