### PR TITLE
Update project to Go 1.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,5 +81,5 @@ updates:
         versions:
           # Ignore updates from series associated with the latest "stable"
           # Go release and no longer supported Go versions.
-          - ">= 1.18"
-          - "< 1.17"
+          - ">= 1.20"
+          - "< 1.19"

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.17.13
+FROM golang:1.19.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/atc0005/mysql2sqlite
 
-go 1.17
+go 1.19
 
 require (
 	github.com/alexflint/go-arg v1.4.3


### PR DESCRIPTION
- update go.mod file from Go 1.17 to 1.19
- update "Canary" Dockerfile to reflect current Go 1.19 version
- update Dependabot configuration for Dockerfile to ignore Go
  releases outside of the Go 1.19 release series