### PR TITLE
Update nagios library usage, add time perfdata

### DIFF
--- a/cmd/check_mysql2sqlite/main_test.go
+++ b/cmd/check_mysql2sqlite/main_test.go
@@ -8,9 +8,12 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/atc0005/go-nagios"
 	"github.com/atc0005/mysql2sqlite/internal/config"
 )
 
@@ -44,4 +47,44 @@ func TestFlagsParsing(t *testing.T) {
 		t.Log("No errors encountered when instantiating configuration")
 	}
 
+}
+
+// TestEmptyClientPerfDataAndConstructedPluginProducesDefaultTimeMetric
+// asserts that omitted performance data from client code produces a default
+// time metric when using the Plugin constructor.
+func TestEmptyClientPerfDataAndConstructedPluginProducesDefaultTimeMetric(t *testing.T) {
+	t.Parallel()
+
+	// Setup Plugin type the same way that client code using the
+	// constructor would.
+	plugin := nagios.NewPlugin()
+
+	// Performance Data metrics are not emitted if we do not supply a
+	// ServiceOutput value.
+	plugin.ServiceOutput = "TacoTuesday"
+
+	var outputBuffer strings.Builder
+
+	plugin.SetOutputTarget(&outputBuffer)
+
+	// os.Exit calls break tests
+	plugin.SkipOSExit()
+
+	// Process exit state, emit output to our output buffer.
+	plugin.ReturnCheckResults()
+
+	want := fmt.Sprintf(
+		"%s | %s",
+		plugin.ServiceOutput,
+		"'time'=",
+	)
+
+	got := outputBuffer.String()
+
+	if !strings.Contains(got, want) {
+		t.Errorf("ERROR: Plugin output does not contain the expected time metric")
+		t.Errorf("\nwant %q\ngot %q", want, got)
+	} else {
+		t.Logf("OK: Emitted performance data contains the expected time metric.")
+	}
 }


### PR DESCRIPTION
- Allow the new nagios package functionality to handle tracking and emitting the `time` metric automatically at plugin completion
- Add test from the atc0005/go-nagios project to assert that the inherited/automatic `time` metric provided by the nagios package is emitted at plugin completion
- Update nagios library usage to reflect dep changes
  - use nagios.NewPlugin constructor in place of manual initialization
  - swap retired ExitState type for new Plugin type

refs GH-203