### PR TITLE
Remove `Push Validation` workflow status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Mirror MySQL database tables to local SQLite database.
 [![go.mod Go version](https://img.shields.io/github/go-mod/go-version/atc0005/mysql2sqlite)](https://github.com/atc0005/mysql2sqlite)
 [![Lint and Build](https://github.com/atc0005/mysql2sqlite/actions/workflows/lint-and-build.yml/badge.svg)](https://github.com/atc0005/mysql2sqlite/actions/workflows/lint-and-build.yml)
 [![Project Analysis](https://github.com/atc0005/mysql2sqlite/actions/workflows/project-analysis.yml/badge.svg)](https://github.com/atc0005/mysql2sqlite/actions/workflows/project-analysis.yml)
-[![Push Validation](https://github.com/atc0005/mysql2sqlite/actions/workflows/push-validation.yml/badge.svg)](https://github.com/atc0005/mysql2sqlite/actions/workflows/push-validation.yml)
 [![Build using Makefile Docker recipes](https://github.com/atc0005/mysql2sqlite/workflows/Build%20using%20Makefile%20Docker%20recipes/badge.svg)](https://github.com/atc0005/mysql2sqlite/actions/workflows/build-using-make-docker-recipes.yml)
 
 <!-- omit in toc -->


### PR DESCRIPTION
This workflow was removed recently, but the "status badge" was unintentionally left behind in the README file.

refs atc0005/shared-project-resources#63
refs atc0005/go-ci#847