### PR TITLE
Add missing os deps list to monthly workflow call

### DIFF
--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -18,4 +18,6 @@ on:
 jobs:
   monthly:
     name: Monthly Tasks
+    with:
+      os-dependencies: "make bsdmainutils gcc gcc-multilib gcc-mingw-w64"
     uses: atc0005/shared-project-resources/.github/workflows/scheduled-monthly.yml@master


### PR DESCRIPTION
This is needed to install the ming packages prior to triggering the `all` Makefile recipe.