### PR TITLE
Use UNKNOWN state for invalid command-line args

### DIFF
--- a/cmd/check_mysql2sqlite/main.go
+++ b/cmd/check_mysql2sqlite/main.go
@@ -40,12 +40,12 @@ func main() {
 	cfg, err := config.NewConfig()
 	if err != nil {
 		plugin.AddError(err)
-		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
 		log.Error(err.Error())
 
 		plugin.ServiceOutput = fmt.Sprintf(
 			"%s: Failed to load configuration: %v",
-			nagios.StateCRITICALLabel,
+			nagios.StateUNKNOWNLabel,
 			err,
 		)
 


### PR DESCRIPTION
Update handling of invalid flags/values to use an UNKNOWN exit state to comply with Nagios Plugin Guideline
recommendations.

refs atc0005/mysql2sqlite#225
refs atc0005/todo#55
refs https://nagios-plugins.org/doc/guidelines.html