### PR TITLE
Update project Go version to use stable release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,7 +79,6 @@ updates:
     ignore:
       - dependency-name: "golang"
         versions:
-          # Ignore updates from series associated with the latest "stable"
-          # Go release and no longer supported Go versions.
-          - ">= 1.20"
-          - "< 1.19"
+          # Track updates to latest stable release series.
+          - ">= 1.21"
+          - "< 1.20"

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.19.9
+FROM golang:1.20.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/atc0005/mysql2sqlite
 
-go 1.19
+go 1.20
 
 require (
 	github.com/alexflint/go-arg v1.4.3


### PR DESCRIPTION
Switch from oldstable (currently Go 1.19) to stable series (currently 1.20). This reflects the recent change to this release series as of the v0.2.8 release.

I intentionally set the Dockerfile one update back to test the Dependabot monitoring changes for that file.