### PR TITLE
Reschedule Makefile container build recipes

### DIFF
--- a/.github/workflows/build-using-make-docker-recipes.yml
+++ b/.github/workflows/build-using-make-docker-recipes.yml
@@ -7,10 +7,9 @@
 
 name: Build using Makefile container recipes
 
-# Run builds for Pull Requests (new, updated)
+# Run container-based builds as directed by calling workflow(s).
 on:
-  pull_request:
-    types: [opened, synchronize]
+  workflow_call:
 
 jobs:
   # This is run from *within* a container that is itself within the GitHub

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -16,8 +16,15 @@ on:
     - cron: "30 4 1 * *"
 
 jobs:
+
+  # Shared "monthly" tasks executed for all projects importing this workflow.
   monthly:
     name: Monthly Tasks
     with:
       os-dependencies: "make bsdmainutils gcc gcc-multilib gcc-mingw-w64 xz-utils"
     uses: atc0005/shared-project-resources/.github/workflows/scheduled-monthly.yml@master
+
+  # CI jobs specific to this project.
+  container_builds:
+    name: Container builds
+    uses: atc0005/mysql2sqlite/.github/workflows/build-using-make-docker-recipes.yml@master


### PR DESCRIPTION
Move from per-PR to scheduled monthly task. We will rely on the less expensive "quick" recipe for per-PR validation.

fixes GH-251