### PR TITLE
Add missing key to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -110,6 +110,7 @@ updates:
       prefix: "canary"
     ignore:
       - dependency-name: "golang"
+        versions:
           # Track updates to latest stable release series.
           - ">= 1.21"
           - "< 1.20"


### PR DESCRIPTION
The versions key was unintentionally removed from the versions constraint applied to the canary Go Dockerfile.