### PR TITLE
Update project to use oldstable build images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -111,7 +111,6 @@ updates:
     ignore:
       - dependency-name: "golang"
         versions:
-          # Track updates to latest stable release series.
           - ">= 1.21"
           - "< 1.20"
 

--- a/dependabot/docker/builds/alpine/x64/Dockerfile
+++ b/dependabot/docker/builds/alpine/x64/Dockerfile
@@ -13,7 +13,7 @@
 
 # https://github.com/atc0005/go-ci/releases
 # https://github.com/atc0005/go-ci/pkgs/container/go-ci
-FROM ghcr.io/atc0005/go-ci:go-ci-stable-alpine-buildx64-v0.13.4
+FROM ghcr.io/atc0005/go-ci:go-ci-oldstable-alpine-buildx64-v0.13.3
 
 # Setup isolated build environment with a full copy of the Git repo contents
 # MINUS any file or path listed in the .dockerignore file at the root of this

--- a/dependabot/docker/builds/alpine/x86/Dockerfile
+++ b/dependabot/docker/builds/alpine/x86/Dockerfile
@@ -13,7 +13,7 @@
 
 # https://github.com/atc0005/go-ci/releases
 # https://github.com/atc0005/go-ci/pkgs/container/go-ci
-FROM ghcr.io/atc0005/go-ci:go-ci-stable-alpine-buildx86-v0.13.4
+FROM ghcr.io/atc0005/go-ci:go-ci-oldstable-alpine-buildx86-v0.13.3
 
 # Setup isolated build environment with a full copy of the Git repo contents
 # MINUS any file or path listed in the .dockerignore file at the root of this


### PR DESCRIPTION
Now that Go 1.20 is the "oldstable" version we switch from using the "stable" build images (previously Go 1.20, now 1.21) to the "oldstable" build images (previously Go 1.19, now 1.20).

This effectively is a NOOP change, continuing the process of generating release assets based on the Go 1.20 series.