### PR TITLE
Generate missing asset links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -869,7 +869,7 @@ release-build-x86: windows-x86-static linux-x86-static windows-x86-links linux-x
 
 .PHONY: release-build-x64
 ## release-build-x64: generates stable x64 build assets for public release
-release-build-x64: windows-x64-static packages-dev clean-linux-x64-dev linux-x64-build-static packages-stable linux-x64-compress linux-x64-checksums linux-x64-links
+release-build-x64: windows-x64-static windows-x64-links packages-dev clean-linux-x64-dev linux-x64-build-static packages-stable package-links linux-x64-compress linux-x64-checksums linux-x64-links
 	@echo "Completed all tasks for x64 stable release build"
 
 .PHONY: release-build


### PR DESCRIPTION
Update `release-build-x64` recipe:

- call `windows-x64-links` recipe
- call `package-links` recipe

refs GH-518