### PR TITLE
Disable Dependabot automatic PR rebasing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,7 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "Go Dependency"
+    rebase-strategy: "disabled"
 
   - package-ecosystem: "gomod"
     directory: "/"
@@ -46,6 +47,7 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "Go Dependency"
+    rebase-strategy: "disabled"
 
   ######################################################################
   # Monitor GitHub Actions dependency updates
@@ -68,6 +70,7 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "CI Dependency"
+    rebase-strategy: "disabled"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -86,6 +89,7 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "CI Dependency"
+    rebase-strategy: "disabled"
 
   ######################################################################
   # Monitor Go updates to service as a reminder to generate new releases
@@ -109,6 +113,7 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "Go Runtime"
+    rebase-strategy: "disabled"
     ignore:
       - dependency-name: "golang"
         versions:
@@ -133,6 +138,7 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "Go Runtime"
+    rebase-strategy: "disabled"
 
   ######################################################################
   # Monitor images used to build project releases
@@ -155,6 +161,7 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "Build Image"
+    rebase-strategy: "disabled"
 
   - package-ecosystem: docker
     directory: "/dependabot/docker/builds/alpine/x86"
@@ -173,6 +180,7 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "Build Image"
+    rebase-strategy: "disabled"
 
   - package-ecosystem: docker
     directory: "/dependabot/docker/builds/alpine/x64"
@@ -191,6 +199,7 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "Build Image"
+    rebase-strategy: "disabled"
 
   - package-ecosystem: docker
     directory: "/dependabot/docker/builds/alpine/x86"
@@ -209,3 +218,4 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "Build Image"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Update the `.github/dependabot.yml` file to include the
`rebase-strategy: "disabled"` setting for each update configuration.

This change is intended to disable automatic rebasing for all open PRs
and instead put that control/timing in the hands of the project
maintainer who can selectively enable rebasing as needed. This is
intended to prevent Dependabot from flooding project queues with
pending/active CI jobs resulting in PRs that a maintainer is actively
working on being held up waiting for their turn to run.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
