### PR TITLE
Fix `tautological condition` linting error

### DIFF
--- a/internal/dbqs/dbqs.go
+++ b/internal/dbqs/dbqs.go
@@ -86,7 +86,7 @@ func VerifyDBConn(ctx context.Context, db *sql.DB, retries int, retryDelay time.
 			)
 			return errMsg
 
-		case result != nil:
+		default:
 
 			log.Warnf(
 				"%s: attempt %d of %d to verify database connection failed: %v",


### PR DESCRIPTION
Use `default` case statement instead of explicit handling for the only other viable alternative to resolve this linting error:

`tautological condition: non-nil != nilnilness`